### PR TITLE
Unindexed vec4 text coordinates for easy merging and manipulation

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,15 +66,9 @@ TextGeometry.prototype.update = function (opt) {
   // get common vertex data
   var positions = vertices.positions(glyphs)
   var uvs = vertices.uvs(glyphs, texWidth, texHeight, flipY)
-  var indices = createIndices({
-    clockwise: true,
-    type: 'uint16',
-    count: glyphs.length
-  })
-
-  // update vertex data
-  buffer.index(this, indices, 1, 'uint16')
-  buffer.attr(this, 'position', positions, 2)
+ 
+   // update vertex data
+  buffer.attr(this, 'position', positions, 4)
   buffer.attr(this, 'uv', uvs, 2)
 
   // update multipage data

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,4 @@
-var itemSize = 2
+var itemSize = 4
 var box = { min: [0, 0], max: [0, 0] }
 
 function bounds (positions) {

--- a/lib/vertices.js
+++ b/lib/vertices.js
@@ -12,7 +12,7 @@ module.exports.pages = function pages (glyphs) {
 }
 
 module.exports.uvs = function uvs (glyphs, texWidth, texHeight, flipY) {
-  var uvs = new Float32Array(glyphs.length * 4 * 2)
+  var uvs = new Float32Array(glyphs.length * 6 * 2)
   var i = 0
   glyphs.forEach(function (glyph) {
     var bitmap = glyph.data
@@ -39,15 +39,21 @@ module.exports.uvs = function uvs (glyphs, texWidth, texHeight, flipY) {
     // TR
     uvs[i++] = u1
     uvs[i++] = v0
+    // TR
+    uvs[i++] = u1
+    uvs[i++] = v0
     // BR
     uvs[i++] = u1
+    uvs[i++] = v1
+    // BL
+    uvs[i++] = u0
     uvs[i++] = v1
   })
   return uvs
 }
 
 module.exports.positions = function positions (glyphs) {
-  var positions = new Float32Array(glyphs.length * 4 * 2)
+  var positions = new Float32Array(glyphs.length * 6 * 4)
   var i = 0
   glyphs.forEach(function (glyph) {
     var bitmap = glyph.data
@@ -63,15 +69,33 @@ module.exports.positions = function positions (glyphs) {
     // BL
     positions[i++] = x
     positions[i++] = y
+    positions[i++] = 0
+    positions[i++] = 0
     // TL
     positions[i++] = x
     positions[i++] = y + h
+    positions[i++] = 0
+    positions[i++] = 0
     // TR
     positions[i++] = x + w
     positions[i++] = y + h
+    positions[i++] = 0
+    positions[i++] = 0
+    // TR
+    positions[i++] = x + w
+    positions[i++] = y + h
+    positions[i++] = 0
+    positions[i++] = 0
     // BR
     positions[i++] = x + w
     positions[i++] = y
+    positions[i++] = 0
+    positions[i++] = 0
+    // BL
+    positions[i++] = x
+    positions[i++] = y
+    positions[i++] = 0
+    positions[i++] = 0
   })
   return positions
 }


### PR DESCRIPTION
#4 This PR changes the text coordinates from vec2 to vec4 and changes the geometry to use unindexed vertices.

The vec2->vec4 change makes it possible to re-position text geometry on Z & use the W-coord for alpha / palette index / bold flag. 

The unindexed vertices change makes merging text geometries easy.
