### PR TITLE
THREE included from npm

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,11 @@ var inherits = require('inherits')
 var createIndices = require('quad-indices')
 var buffer = require('three-buffer-vertex-data')
 var assign = require('object-assign')
+var THREE = require('three')
 
 var vertices = require('./lib/vertices')
 var utils = require('./lib/utils')
+
 
 var Base = THREE.BufferGeometry
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "layout-bmfont-text": "^1.2.0",
     "object-assign": "^4.0.1",
     "quad-indices": "^2.0.1",
-    "three": "^0.70.1",
+    "three": "^0.79.1",
     "three-buffer-vertex-data": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "layout-bmfont-text": "^1.2.0",
     "object-assign": "^4.0.1",
     "quad-indices": "^2.0.1",
-    "three": "^0.79.1",
+    "three": "^0.79.0",
     "three-buffer-vertex-data": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "layout-bmfont-text": "^1.2.0",
     "object-assign": "^4.0.1",
     "quad-indices": "^2.0.1",
+    "three": "^0.70.1",
     "three-buffer-vertex-data": "^1.0.0"
   },
   "devDependencies": {
@@ -31,7 +32,6 @@
     "load-bmfont": "^1.0.0",
     "standard": "^5.4.1",
     "sun-tzu-quotes": "^1.0.0",
-    "three": "^0.70.0",
     "three-orbit-viewer": "^69.2.9",
     "three-vignette-background": "^1.0.2",
     "uglify-js": "^2.4.17"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "object-assign": "^4.0.1",
     "quad-indices": "^2.0.1",
     "three": "^0.79.0",
-    "three-buffer-vertex-data": "^1.0.0"
+    "three-buffer-vertex-data": "^1.0.1"
   },
   "devDependencies": {
     "bluebird": "^2.9.14",

--- a/shaders/basic.js
+++ b/shaders/basic.js
@@ -1,3 +1,4 @@
+var THREE = require('three')
 var assign = require('object-assign')
 
 module.exports = function createBasicShader (opt) {

--- a/shaders/multipage.js
+++ b/shaders/multipage.js
@@ -1,3 +1,4 @@
+var THREE = require('three')
 var assign = require('object-assign')
 
 module.exports = function createMultipageShader (opt) {

--- a/shaders/sdf.js
+++ b/shaders/sdf.js
@@ -1,3 +1,4 @@
+var THREE = require('three')
 var assign = require('object-assign')
 
 module.exports = function createSDFShader (opt) {


### PR DESCRIPTION
I added requiring THREE.js from npm. I think it will be easier to connect the library. A lot of developers builds projects with build tools such as webpack. And this tools works very good with npm modules.