### PR TITLE
Make it compatible with cjs style of importing THREE

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ var createIndices = require('quad-indices')
 var vertices = require('./lib/vertices')
 var utils = require('./lib/utils')
 
+var has_require = typeof require !== 'undefined'
+var THREE = root.THREE || (has_require && require('three'))
+
 var Base = THREE.BufferGeometry
 
 module.exports = function createTextGeometry (opt) {


### PR DESCRIPTION
Because in my typescript project. three.js was included in a module. Calling THREE.BufferGeometry directly doesn't work.

<!--
Please make sure to read the Contributing Guidelines:
https://github.com/Jam3/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the PR Title -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Did you test your solution?**

- [ ] I lightly tested it in one browser
- [x] I deeply tested it in several browsers
- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)

## Problem Description

<!--- Describe the problem briefly or reference related issues -->

## Solution Description

<!--- Describe your changes in detail -->

## Side Effects, Risks, Impact

<!--- May your changes break other parts of the application? -->

- [ ] N/A

**Aditional comments:**
