### PR TITLE
Fix/shaders update

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var createLayout = require('layout-bmfont-text')
-var inherits = require('inherits')
 var createIndices = require('quad-indices')
 
 var vertices = require('./lib/vertices')
@@ -10,113 +9,117 @@ var Base = THREE.BufferGeometry
 module.exports = function createTextGeometry (opt) {
   return new TextGeometry(opt)
 }
+class TextGeometry extends Base {
+  constructor (opt) {
+    super()
 
-function TextGeometry (opt) {
-  Base.call(this)
+    this.type = 'TextGeometry'
 
-  if (typeof opt === 'string') {
-    opt = { text: opt }
+    if (typeof opt === 'string') {
+      this.parameters = {
+        opt: opt
+      }
+    }
+    // use these as default values for any subsequent
+    // calls to update()
+    this._opt = Object.assign({}, opt)
+
+    // also do an initial setup...
+    if (opt) this.update(opt)
   }
 
-  // use these as default values for any subsequent
-  // calls to update()
-  this._opt = Object.assign({}, opt)
+  update (opt) {
+    if (typeof opt === 'string') {
+      opt = { text: opt }
+    }
 
-  // also do an initial setup...
-  if (opt) this.update(opt)
-}
+    // use constructor defaults
+    opt = Object.assign({}, this._opt, opt)
 
-inherits(TextGeometry, Base)
+    if (!opt.font) {
+      throw new TypeError('must specify a { font } in options')
+    }
 
-TextGeometry.prototype.update = function (opt) {
-  if (typeof opt === 'string') {
-    opt = { text: opt }
+    this.layout = createLayout(opt)
+
+    // get vec2 texcoords
+    var flipY = opt.flipY !== false
+
+    // the desired BMFont data
+    var font = opt.font
+
+    // determine texture size from font file
+    var texWidth = font.common.scaleW
+    var texHeight = font.common.scaleH
+
+    // get visible glyphs
+    var glyphs = this.layout.glyphs.filter(function (glyph) {
+      var bitmap = glyph.data
+      return bitmap.width * bitmap.height > 0
+    })
+
+    // provide visible glyphs for convenience
+    this.visibleGlyphs = glyphs
+
+    // get common vertex data
+    var positions = vertices.positions(glyphs)
+    var uvs = vertices.uvs(glyphs, texWidth, texHeight, flipY)
+    var indices = createIndices([], {
+      clockwise: true,
+      type: 'uint16',
+      count: glyphs.length
+    })
+
+    // update vertex data
+    this.setIndex(indices)
+    this.setAttribute('position', new THREE.BufferAttribute(positions, 2))
+    this.setAttribute('uv', new THREE.BufferAttribute(uvs, 2))
+
+    // update multipage data
+    if (!opt.multipage && 'page' in this.attributes) {
+      // disable multipage rendering
+      this.removeAttribute('page')
+    } else if (opt.multipage) {
+      // enable multipage rendering
+      var pages = vertices.pages(glyphs)
+      this.setAttribute('page', new THREE.BufferAttribute(pages, 1))
+    }
   }
 
-  // use constructor defaults
-  opt = Object.assign({}, this._opt, opt)
+  computeBoundingSphere () {
+    if (this.boundingSphere === null) {
+      this.boundingSphere = new THREE.Sphere()
+    }
 
-  if (!opt.font) {
-    throw new TypeError('must specify a { font } in options')
+    var positions = this.attributes.position.array
+    var itemSize = this.attributes.position.itemSize
+    if (!positions || !itemSize || positions.length < 2) {
+      this.boundingSphere.radius = 0
+      this.boundingSphere.center.set(0, 0, 0)
+      return
+    }
+    utils.computeSphere(positions, this.boundingSphere)
+    if (isNaN(this.boundingSphere.radius)) {
+      console.error(
+				`THREE.BufferGeometry.computeBoundingSphere():
+Computed radius is NaN. The
+"position" attribute is likely to have NaN values.`
+      )
+    }
   }
 
-  this.layout = createLayout(opt)
+  computeBoundingBox () {
+    if (this.boundingBox === null) {
+      this.boundingBox = new THREE.Box3()
+    }
 
-  // get vec2 texcoords
-  var flipY = opt.flipY !== false
-
-  // the desired BMFont data
-  var font = opt.font
-
-  // determine texture size from font file
-  var texWidth = font.common.scaleW
-  var texHeight = font.common.scaleH
-
-  // get visible glyphs
-  var glyphs = this.layout.glyphs.filter(function (glyph) {
-    var bitmap = glyph.data
-    return bitmap.width * bitmap.height > 0
-  })
-
-  // provide visible glyphs for convenience
-  this.visibleGlyphs = glyphs
-
-  // get common vertex data
-  var positions = vertices.positions(glyphs)
-  var uvs = vertices.uvs(glyphs, texWidth, texHeight, flipY)
-  var indices = createIndices([], {
-    clockwise: true,
-    type: 'uint16',
-    count: glyphs.length
-  })
-
-  // update vertex data
-  this.setIndex(indices)
-  this.setAttribute('position', new THREE.BufferAttribute(positions, 2))
-  this.setAttribute('uv', new THREE.BufferAttribute(uvs, 2))
-
-  // update multipage data
-  if (!opt.multipage && 'page' in this.attributes) {
-    // disable multipage rendering
-    this.removeAttribute('page')
-  } else if (opt.multipage) {
-    // enable multipage rendering
-    var pages = vertices.pages(glyphs)
-    this.setAttribute('page', new THREE.BufferAttribute(pages, 1))
+    var bbox = this.boundingBox
+    var positions = this.attributes.position.array
+    var itemSize = this.attributes.position.itemSize
+    if (!positions || !itemSize || positions.length < 2) {
+      bbox.makeEmpty()
+      return
+    }
+    utils.computeBox(positions, bbox)
   }
-}
-
-TextGeometry.prototype.computeBoundingSphere = function () {
-  if (this.boundingSphere === null) {
-    this.boundingSphere = new THREE.Sphere()
-  }
-
-  var positions = this.attributes.position.array
-  var itemSize = this.attributes.position.itemSize
-  if (!positions || !itemSize || positions.length < 2) {
-    this.boundingSphere.radius = 0
-    this.boundingSphere.center.set(0, 0, 0)
-    return
-  }
-  utils.computeSphere(positions, this.boundingSphere)
-  if (isNaN(this.boundingSphere.radius)) {
-    console.error('THREE.BufferGeometry.computeBoundingSphere(): ' +
-      'Computed radius is NaN. The ' +
-      '"position" attribute is likely to have NaN values.')
-  }
-}
-
-TextGeometry.prototype.computeBoundingBox = function () {
-  if (this.boundingBox === null) {
-    this.boundingBox = new THREE.Box3()
-  }
-
-  var bbox = this.boundingBox
-  var positions = this.attributes.position.array
-  var itemSize = this.attributes.position.itemSize
-  if (!positions || !itemSize || positions.length < 2) {
-    bbox.makeEmpty()
-    return
-  }
-  utils.computeBox(positions, bbox)
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var createLayout = require('layout-bmfont-text')
+var inherits = require('inherits')
 var createIndices = require('quad-indices')
 
 var vertices = require('./lib/vertices')
@@ -6,120 +7,118 @@ var utils = require('./lib/utils')
 
 var Base = THREE.BufferGeometry
 
-module.exports = function createTextGeometry (opt) {
-  return new TextGeometry(opt)
+module.exports = function createTextGeometry(opt) {
+	return new TextGeometry(opt)
 }
-class TextGeometry extends Base {
-  constructor (opt) {
-    super()
 
-    this.type = 'TextGeometry'
+function TextGeometry(opt) {
+	Base.call(this)
 
-    if (typeof opt === 'string') {
-      this.parameters = {
-        opt: opt
-      }
-    }
-    // use these as default values for any subsequent
-    // calls to update()
-    this._opt = Object.assign({}, opt)
+	if (typeof opt === 'string') {
+		opt = { text: opt }
+	}
 
-    // also do an initial setup...
-    if (opt) this.update(opt)
-  }
+	// use these as default values for any subsequent
+	// calls to update()
+	this._opt = Object.assign({}, opt)
 
-  update (opt) {
-    if (typeof opt === 'string') {
-      opt = { text: opt }
-    }
+	// also do an initial setup...
+	if (opt) this.update(opt)
+}
 
-    // use constructor defaults
-    opt = Object.assign({}, this._opt, opt)
+inherits(TextGeometry, Base)
 
-    if (!opt.font) {
-      throw new TypeError('must specify a { font } in options')
-    }
+TextGeometry.prototype.update = function (opt) {
+	if (typeof opt === 'string') {
+		opt = { text: opt }
+	}
 
-    this.layout = createLayout(opt)
+	// use constructor defaults
+	opt = Object.assign({}, this._opt, opt)
 
-    // get vec2 texcoords
-    var flipY = opt.flipY !== false
+	if (!opt.font) {
+		throw new TypeError('must specify a { font } in options')
+	}
 
-    // the desired BMFont data
-    var font = opt.font
+	this.layout = createLayout(opt)
 
-    // determine texture size from font file
-    var texWidth = font.common.scaleW
-    var texHeight = font.common.scaleH
+	// get vec2 texcoords
+	var flipY = opt.flipY !== false
 
-    // get visible glyphs
-    var glyphs = this.layout.glyphs.filter(function (glyph) {
-      var bitmap = glyph.data
-      return bitmap.width * bitmap.height > 0
-    })
+	// the desired BMFont data
+	var font = opt.font
 
-    // provide visible glyphs for convenience
-    this.visibleGlyphs = glyphs
+	// determine texture size from font file
+	var texWidth = font.common.scaleW
+	var texHeight = font.common.scaleH
 
-    // get common vertex data
-    var positions = vertices.positions(glyphs)
-    var uvs = vertices.uvs(glyphs, texWidth, texHeight, flipY)
-    var indices = createIndices([], {
-      clockwise: true,
-      type: 'uint16',
-      count: glyphs.length
-    })
+	// get visible glyphs
+	var glyphs = this.layout.glyphs.filter(function (glyph) {
+		var bitmap = glyph.data
+		return bitmap.width * bitmap.height > 0
+	})
 
-    // update vertex data
-    this.setIndex(indices)
-    this.setAttribute('position', new THREE.BufferAttribute(positions, 2))
-    this.setAttribute('uv', new THREE.BufferAttribute(uvs, 2))
+	// provide visible glyphs for convenience
+	this.visibleGlyphs = glyphs
 
-    // update multipage data
-    if (!opt.multipage && 'page' in this.attributes) {
-      // disable multipage rendering
-      this.removeAttribute('page')
-    } else if (opt.multipage) {
-      // enable multipage rendering
-      var pages = vertices.pages(glyphs)
-      this.setAttribute('page', new THREE.BufferAttribute(pages, 1))
-    }
-  }
+	// get common vertex data
+	var positions = vertices.positions(glyphs)
+	var uvs = vertices.uvs(glyphs, texWidth, texHeight, flipY)
+	var indices = createIndices([], {
+		clockwise: true,
+		type: 'uint16',
+		count: glyphs.length,
+	})
 
-  computeBoundingSphere () {
-    if (this.boundingSphere === null) {
-      this.boundingSphere = new THREE.Sphere()
-    }
+	// update vertex data
+	this.setIndex(indices)
+	this.setAttribute('position', new THREE.BufferAttribute(positions, 2))
+	this.setAttribute('uv', new THREE.BufferAttribute(uvs, 2))
 
-    var positions = this.attributes.position.array
-    var itemSize = this.attributes.position.itemSize
-    if (!positions || !itemSize || positions.length < 2) {
-      this.boundingSphere.radius = 0
-      this.boundingSphere.center.set(0, 0, 0)
-      return
-    }
-    utils.computeSphere(positions, this.boundingSphere)
-    if (isNaN(this.boundingSphere.radius)) {
-      console.error(
-				`THREE.BufferGeometry.computeBoundingSphere():
-Computed radius is NaN. The
-"position" attribute is likely to have NaN values.`
-      )
-    }
-  }
+	// update multipage data
+	if (!opt.multipage && 'page' in this.attributes) {
+		// disable multipage rendering
+		this.removeAttribute('page')
+	} else if (opt.multipage) {
+		// enable multipage rendering
+		var pages = vertices.pages(glyphs)
+		this.setAttribute('page', new THREE.BufferAttribute(pages, 1))
+	}
+}
 
-  computeBoundingBox () {
-    if (this.boundingBox === null) {
-      this.boundingBox = new THREE.Box3()
-    }
+TextGeometry.prototype.computeBoundingSphere = function () {
+	if (this.boundingSphere === null) {
+		this.boundingSphere = new THREE.Sphere()
+	}
 
-    var bbox = this.boundingBox
-    var positions = this.attributes.position.array
-    var itemSize = this.attributes.position.itemSize
-    if (!positions || !itemSize || positions.length < 2) {
-      bbox.makeEmpty()
-      return
-    }
-    utils.computeBox(positions, bbox)
-  }
+	var positions = this.attributes.position.array
+	var itemSize = this.attributes.position.itemSize
+	if (!positions || !itemSize || positions.length < 2) {
+		this.boundingSphere.radius = 0
+		this.boundingSphere.center.set(0, 0, 0)
+		return
+	}
+	utils.computeSphere(positions, this.boundingSphere)
+	if (isNaN(this.boundingSphere.radius)) {
+		console.error(
+			'THREE.BufferGeometry.computeBoundingSphere(): ' +
+				'Computed radius is NaN. The ' +
+				'"position" attribute is likely to have NaN values.'
+		)
+	}
+}
+
+TextGeometry.prototype.computeBoundingBox = function () {
+	if (this.boundingBox === null) {
+		this.boundingBox = new THREE.Box3()
+	}
+
+	var bbox = this.boundingBox
+	var positions = this.attributes.position.array
+	var itemSize = this.attributes.position.itemSize
+	if (!positions || !itemSize || positions.length < 2) {
+		bbox.makeEmpty()
+		return
+	}
+	utils.computeBox(positions, bbox)
 }

--- a/shaders/msdf.js
+++ b/shaders/msdf.js
@@ -1,61 +1,84 @@
-var assign = require('object-assign');
+var assign = require('object-assign')
 
 module.exports = function createMSDFShader (opt) {
-  opt = opt || {};
-  var opacity = typeof opt.opacity === 'number' ? opt.opacity : 1;
-  var alphaTest = typeof opt.alphaTest === 'number' ? opt.alphaTest : 0.0001;
-  var precision = opt.precision || 'highp';
-  var color = opt.color;
-  var map = opt.map;
-  var negate = typeof opt.negate === 'boolean' ? opt.negate : true;
+  opt = opt || {}
+  var opacity = typeof opt.opacity === 'number' ? opt.opacity : 1
+  var alphaTest = typeof opt.alphaTest === 'number' ? opt.alphaTest : 0.0001
+  var precision = opt.precision || 'highp'
+  var color = opt.color
+  var map = opt.map
+  var negate = typeof opt.negate === 'boolean' ? opt.negate : true
 
   // remove to satisfy r73
-  delete opt.map;
-  delete opt.color;
-  delete opt.precision;
-  delete opt.opacity;
-  delete opt.negate;
+  delete opt.map
+  delete opt.color
+  delete opt.precision
+  delete opt.opacity
+  delete opt.negate
 
-  return assign({
-    uniforms: {
-      opacity: { type: 'f', value: opacity },
-      map: { type: 't', value: map || new THREE.Texture() },
-      color: { type: 'c', value: new THREE.Color(color) }
+  const webgl2 = document.getElementsByTagName('canvas')[0].getContext('webgl2')
+
+  return assign(
+    {
+      uniforms: {
+        opacity: { value: opacity },
+        map: { value: map || new THREE.Texture() },
+        color: { value: new THREE.Color(color) }
+      },
+      vertexShader: `${
+				webgl2
+					? `#version 300 es
+
+#define attribute in
+#define varying out`
+					: ''
+			}
+attribute vec2 uv;
+attribute vec3 position;
+uniform mat4 projectionMatrix;
+uniform mat4 modelViewMatrix;
+
+varying vec2 vUv;
+
+void main() {
+	vUv = uv;
+	gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}`,
+      fragmentShader: `${
+				webgl2
+					? `#version 300 es
+#define varying in
+out highp vec4 pc_fragColor;
+
+#define texture2D texture
+#define gl_FragColor pc_fragColor`
+					: ''
+			}
+							
+#ifdef GL_OES_standard_derivatives
+	#extension GL_OES_standard_derivatives : enable
+#endif
+
+precision ${precision} float;
+
+uniform float opacity;
+uniform vec3 color;
+uniform sampler2D map;
+
+varying vec2 vUv;
+
+float median(float r, float g, float b) {
+	return max(min(r, g), min(max(r, g), b));
+}
+
+void main() {
+	vec3 samp = ${negate ? '1.0 - ' : ''} texture2D(map, vUv).rgb;
+	float sigDist = median(samp.r, samp.g, samp.b) - 0.5;
+	float alpha = clamp(sigDist/fwidth(sigDist) + 0.5, 0.0, 1.0);
+	gl_FragColor = vec4(color.xyz, alpha * opacity);
+	${alphaTest === 0 ? '' : `if (gl_FragColor.a < ${alphaTest}) discard;`}
+}`
     },
-    vertexShader: [
-      'attribute vec2 uv;',
-      'attribute vec4 position;',
-      'uniform mat4 projectionMatrix;',
-      'uniform mat4 modelViewMatrix;',
-      'varying vec2 vUv;',
-      'void main() {',
-      'vUv = uv;',
-      'gl_Position = projectionMatrix * modelViewMatrix * position;',
-      '}'
-    ].join('\n'),
-    fragmentShader: [
-      '#ifdef GL_OES_standard_derivatives',
-      '#extension GL_OES_standard_derivatives : enable',
-      '#endif',
-      'precision ' + precision + ' float;',
-      'uniform float opacity;',
-      'uniform vec3 color;',
-      'uniform sampler2D map;',
-      'varying vec2 vUv;',
-
-      'float median(float r, float g, float b) {',
-      '  return max(min(r, g), min(max(r, g), b));',
-      '}',
-
-      'void main() {',
-      '  vec3 sample = ' + (negate ? '1.0 - ' : '') + 'texture2D(map, vUv).rgb;',
-      '  float sigDist = median(sample.r, sample.g, sample.b) - 0.5;',
-      '  float alpha = clamp(sigDist/fwidth(sigDist) + 0.5, 0.0, 1.0);',
-      '  gl_FragColor = vec4(color.xyz, alpha * opacity);',
-      alphaTest === 0
-        ? ''
-        : '  if (gl_FragColor.a < ' + alphaTest + ') discard;',
-      '}'
-    ].join('\n')
-  }, opt);
-};
+    opt
+  )
+}

--- a/shaders/multipage.js
+++ b/shaders/multipage.js
@@ -7,28 +7,30 @@ module.exports = function createMultipageShader (opt) {
   var alphaTest = typeof opt.alphaTest === 'number' ? opt.alphaTest : 0.0001
 
   var textures = opt.textures || []
-  textures = Array.isArray(textures) ? textures : [ textures ]
+  textures = Array.isArray(textures) ? textures : [textures]
 
   var baseUniforms = {}
-  textures.forEach(function (tex, i) {
-    baseUniforms['texture' + i] = {
-      type: 't',
+  textures.forEach((tex, i) => {
+    baseUniforms[`texture${i}`] = {
       value: tex
     }
   })
 
-  var samplers = textures.map(function (tex, i) {
-    return 'uniform sampler2D texture' + i + ';'
-  }).join('\n')
+  var samplers = textures
+    .map((tex, i) => {
+      return `uniform sampler2D texture${i};
+      `
+    })
+    .join('')
 
-  var body = textures.map(function (tex, i) {
-    var cond = i === 0 ? 'if' : 'else if'
-    return [
-      cond + ' (vPage == ' + i + '.0) {',
-      'sampleColor = texture2D(texture' + i + ', vUv);',
-      '}'
-    ].join('\n')
-  }).join('\n')
+  var body = textures
+    .map((tex, i) => {
+      var cond = i === 0 ? 'if' : 'else if'
+      return `${cond} (vPage == ${i}.0) {
+				  sampleColor = texture2D(texture${i}, vUv);
+				}`
+    })
+    .join('')
 
   var color = opt.color
 
@@ -38,8 +40,10 @@ module.exports = function createMultipageShader (opt) {
   delete opt.precision
   delete opt.opacity
 
+  const webgl2 = document.getElementsByTagName('canvas')[0].getContext('webgl2')
+
   var attributes = {
-    attributes: { page: { type: 'f', value: 0 } }
+    attributes: { page: { value: 0 } }
   }
 
   var threeVers = (parseInt(THREE.REVISION, 10) || 0) | 0
@@ -47,40 +51,62 @@ module.exports = function createMultipageShader (opt) {
     attributes = undefined
   }
 
-  return assign({
-    uniforms: assign({}, baseUniforms, {
-      opacity: { type: 'f', value: opacity },
-      color: { type: 'c', value: new THREE.Color(color) }
-    }),
-    vertexShader: [
-      'attribute vec4 position;',
-      'attribute vec2 uv;',
-      'attribute float page;',
-      'uniform mat4 projectionMatrix;',
-      'uniform mat4 modelViewMatrix;',
-      'varying vec2 vUv;',
-      'varying float vPage;',
-      'void main() {',
-      'vUv = uv;',
-      'vPage = page;',
-      'gl_Position = projectionMatrix * modelViewMatrix * position;',
-      '}'
-    ].join('\n'),
-    fragmentShader: [
-      'precision ' + precision + ' float;',
-      'uniform float opacity;',
-      'uniform vec3 color;',
-      samplers,
-      'varying float vPage;',
-      'varying vec2 vUv;',
-      'void main() {',
-      'vec4 sampleColor = vec4(0.0);',
-      body,
-      'gl_FragColor = sampleColor * vec4(color, opacity);',
-      alphaTest === 0
-        ? ''
-        : '  if (gl_FragColor.a < ' + alphaTest + ') discard;',
-      '}'
-    ].join('\n')
-  }, attributes, opt)
+  return assign(
+    {
+      uniforms: assign({}, baseUniforms, {
+        opacity: { value: opacity },
+        color: { value: new THREE.Color(color) }
+      }),
+      vertexShader: `${
+				webgl2
+					? `#version 300 es
+
+#define attribute in
+#define varying out`
+					: ''
+			}
+attribute vec3 position;
+attribute vec2 uv;
+attribute float page;
+
+uniform mat4 projectionMatrix;
+uniform mat4 modelViewMatrix;
+
+varying vec2 vUv;
+varying float vPage;
+
+void main() {
+  vUv = uv;
+  vPage = page;
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}`,
+      fragmentShader: `${
+				webgl2
+					? `#version 300 es
+#define varying in
+out highp vec4 pc_fragColor;
+
+#define texture2D texture
+#define gl_FragColor pc_fragColor`
+					: ''
+			}
+precision ${precision} float;
+uniform float opacity;
+uniform vec3 color;
+
+${samplers}
+
+varying float vPage;
+varying vec2 vUv;
+
+void main() {
+  vec4 sampleColor = vec4(0.0);
+  ${body}
+  gl_FragColor = sampleColor * vec4(color, opacity);
+  ${alphaTest === 0 ? '' : `if (gl_FragColor.a < ${alphaTest}) discard;`}
+}`
+    },
+    attributes,
+    opt
+  )
 }

--- a/test/load.js
+++ b/test/load.js
@@ -3,11 +3,10 @@ global.THREE = require('three')
 
 // A utility to load a font, then a texture
 module.exports = function (opt, cb) {
-  loadFont(opt.font, function (err, font) {
-    if (err) throw err
-    const loader = new THREE.TextureLoader()
-    loader.load(opt.image, function (tex) {
-      cb(font, tex)
-    })
-  })
+	loadFont(opt.font, function (err, font) {
+		if (err) throw err
+		THREE.ImageUtils.loadTexture(opt.image, undefined, function (tex) {
+			cb(font, tex)
+		})
+	})
 }

--- a/test/load.js
+++ b/test/load.js
@@ -5,7 +5,8 @@ global.THREE = require('three')
 module.exports = function (opt, cb) {
   loadFont(opt.font, function (err, font) {
     if (err) throw err
-    THREE.ImageUtils.loadTexture(opt.image, undefined, function (tex) {
+    const loader = new THREE.TextureLoader()
+    loader.load(opt.image, function (tex) {
       cb(font, tex)
     })
   })


### PR DESCRIPTION
Updated all shaders to check for WebGL 2 context on the canvas element before compiling. If a WebGL 2 context is found, Open GL 3.0 syntax is inserted at the beginning of each shader. Code is also mildly style updated to utilize template literals. 

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Did you test your solution?**

- [x] I lightly tested it in one browser
- [ ] I deeply tested it in several browsers
- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)

## Problem Description

As noted in #38, shaders have been broken since THREE.js r118. I believe it is because these newer THREE.js versions are expecting OpenGL ES 3.0 syntax in their shaders. 

## Solution Description

I added a check in each shader to look for WebGL 2 rendering context on the canvas. If no WebGL rendering context is found, the shaders remain more or less untouched (see below). Otherwise, if WebGL 2 context is found, the shaders use template literals to insert OpenGL ES 3.0 syntax at the head of each shader. 

Template literals are also now used throughout the shaders for ease of use and readability. 

The only other slight change is found in the vertex shaders. They now import position as a vec3 attribute, inserting the attribute into a vec4 inside the main function. I believe this change is inconsequential, merely adopting the format of the standard THREE.js shaders. 

## Side Effects, Risks, Impact

I found no side effects when testing this in my own projects as well as internally testing the npm scrips in the package.json. 

- [ ] N/A

**Aditional comments:**

I believe that the tests in this repo are actually using a much later version of THREE.js than the dependency found in the package.json. I was playing around with updating a lot of these dependencies before committing to these specific shader changes, and I couldn't figure out why updating THREE.js to the latest version wasn't demanding OpenGL ES 3.0 on the shaders (which is actually what led me to think of adding a WebGL 2 check on the canvas before compiling each shader). I traced it to the three-orbit-viewer, and from there, three-orbit-controls. Updating the dependencies on those didn't seem to break anything, but it also didn't generate a WebGL 2 canvas either, so I ended up leaving that dependency rabbit hole for the time being in the interest of doing something more productive. 

Hopefully this update will allow people using later versions of THREE.js to use the repo out of the box, without needing to dig into the shaders unless they want to, while also allowing people using currently using this repo with older THREE.js versions to continue updating it without breaking any functionality. 

PS the first commit also included changes to index.js and load.js, which I rolled back and am including in a separate PR, as they aren't related to the shader changes at all. 