### PR TITLE
改写为es6语法，解决在新版Aframe框架中的报错

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,122 +1,125 @@
 var createLayout = require('layout-bmfont-text')
-var inherits = require('inherits')
+// var inherits = require('inherits')
+// const util = require('util');
+
 var createIndices = require('quad-indices')
+var buffer = require('three-buffer-vertex-data')
+var assign = require('object-assign')
 
-var vertices = require('./lib/vertices')
-var utils = require('./lib/utils')
-
-var Base = THREE.BufferGeometry
+var vertices = require('three-bmfont-text/lib/vertices')
+var utils = require('three-bmfont-text/lib/utils')
 
 module.exports = function createTextGeometry (opt) {
   return new TextGeometry(opt)
 }
 
-function TextGeometry (opt) {
-  Base.call(this)
+class TextGeometry extends THREE.BufferGeometry {
+  constructor(opt){
+    super()
 
-  if (typeof opt === 'string') {
-    opt = { text: opt }
+    if (typeof opt === 'string') {
+      opt = { text: opt }
+    }
+  
+    // use these as default values for any subsequent
+    // calls to update()
+    this._opt = assign({}, opt)
+  
+    // also do an initial setup...
+    if (opt) this.update(opt)
   }
 
-  // use these as default values for any subsequent
-  // calls to update()
-  this._opt = Object.assign({}, opt)
-
-  // also do an initial setup...
-  if (opt) this.update(opt)
-}
-
-inherits(TextGeometry, Base)
-
-TextGeometry.prototype.update = function (opt) {
-  if (typeof opt === 'string') {
-    opt = { text: opt }
+  update (opt) {
+    if (typeof opt === 'string') {
+      opt = { text: opt }
+    }
+  
+    // use constructor defaults
+    opt = assign({}, this._opt, opt)
+  
+    if (!opt.font) {
+      throw new TypeError('must specify a { font } in options')
+    }
+  
+    this.layout = createLayout(opt)
+  
+    // get vec2 texcoords
+    var flipY = opt.flipY !== false
+  
+    // the desired BMFont data
+    var font = opt.font
+  
+    // determine texture size from font file
+    var texWidth = font.common.scaleW
+    var texHeight = font.common.scaleH
+  
+    // get visible glyphs
+    var glyphs = this.layout.glyphs.filter(function (glyph) {
+      var bitmap = glyph.data
+      return bitmap.width * bitmap.height > 0
+    })
+  
+    // provide visible glyphs for convenience
+    this.visibleGlyphs = glyphs
+  
+    // get common vertex data
+    var positions = vertices.positions(glyphs)
+    var uvs = vertices.uvs(glyphs, texWidth, texHeight, flipY)
+    var indices = createIndices({
+      clockwise: true,
+      type: 'uint16',
+      count: glyphs.length
+    })
+  
+    // update vertex data
+    buffer.index(this, indices, 1, 'uint16')
+    buffer.attr(this, 'position', positions, 2)
+    buffer.attr(this, 'uv', uvs, 2)
+  
+    // update multipage data
+    if (!opt.multipage && 'page' in this.attributes) {
+      // disable multipage rendering
+      this.deleteAttribute('page')
+    } else if (opt.multipage) {
+      var pages = vertices.pages(glyphs)
+      // enable multipage rendering
+      buffer.attr(this, 'page', pages, 1)
+    }
   }
-
-  // use constructor defaults
-  opt = Object.assign({}, this._opt, opt)
-
-  if (!opt.font) {
-    throw new TypeError('must specify a { font } in options')
+  
+  computeBoundingSphere () {
+    if (this.boundingSphere === null) {
+      this.boundingSphere = new THREE.Sphere()
+    }
+  
+    var positions = this.attributes.position.array
+    var itemSize = this.attributes.position.itemSize
+    if (!positions || !itemSize || positions.length < 2) {
+      this.boundingSphere.radius = 0
+      this.boundingSphere.center.set(0, 0, 0)
+      return
+    }
+    utils.computeSphere(positions, this.boundingSphere)
+    if (isNaN(this.boundingSphere.radius)) {
+      console.error('THREE.BufferGeometry.computeBoundingSphere(): ' +
+        'Computed radius is NaN. The ' +
+        '"position" attribute is likely to have NaN values.')
+    }
   }
-
-  this.layout = createLayout(opt)
-
-  // get vec2 texcoords
-  var flipY = opt.flipY !== false
-
-  // the desired BMFont data
-  var font = opt.font
-
-  // determine texture size from font file
-  var texWidth = font.common.scaleW
-  var texHeight = font.common.scaleH
-
-  // get visible glyphs
-  var glyphs = this.layout.glyphs.filter(function (glyph) {
-    var bitmap = glyph.data
-    return bitmap.width * bitmap.height > 0
-  })
-
-  // provide visible glyphs for convenience
-  this.visibleGlyphs = glyphs
-
-  // get common vertex data
-  var positions = vertices.positions(glyphs)
-  var uvs = vertices.uvs(glyphs, texWidth, texHeight, flipY)
-  var indices = createIndices([], {
-    clockwise: true,
-    type: 'uint16',
-    count: glyphs.length
-  })
-
-  // update vertex data
-  this.setIndex(indices)
-  this.setAttribute('position', new THREE.BufferAttribute(positions, 2))
-  this.setAttribute('uv', new THREE.BufferAttribute(uvs, 2))
-
-  // update multipage data
-  if (!opt.multipage && 'page' in this.attributes) {
-    // disable multipage rendering
-    this.removeAttribute('page')
-  } else if (opt.multipage) {
-    // enable multipage rendering
-    var pages = vertices.pages(glyphs)
-    this.setAttribute('page', new THREE.BufferAttribute(pages, 1))
+  
+  computeBoundingBox() {
+    if (this.boundingBox === null) {
+      this.boundingBox = new THREE.Box3()
+    }
+  
+    var bbox = this.boundingBox
+    var positions = this.attributes.position.array
+    var itemSize = this.attributes.position.itemSize
+    if (!positions || !itemSize || positions.length < 2) {
+      bbox.makeEmpty()
+      return
+    }
+    utils.computeBox(positions, bbox)
   }
-}
-
-TextGeometry.prototype.computeBoundingSphere = function () {
-  if (this.boundingSphere === null) {
-    this.boundingSphere = new THREE.Sphere()
-  }
-
-  var positions = this.attributes.position.array
-  var itemSize = this.attributes.position.itemSize
-  if (!positions || !itemSize || positions.length < 2) {
-    this.boundingSphere.radius = 0
-    this.boundingSphere.center.set(0, 0, 0)
-    return
-  }
-  utils.computeSphere(positions, this.boundingSphere)
-  if (isNaN(this.boundingSphere.radius)) {
-    console.error('THREE.BufferGeometry.computeBoundingSphere(): ' +
-      'Computed radius is NaN. The ' +
-      '"position" attribute is likely to have NaN values.')
-  }
-}
-
-TextGeometry.prototype.computeBoundingBox = function () {
-  if (this.boundingBox === null) {
-    this.boundingBox = new THREE.Box3()
-  }
-
-  var bbox = this.boundingBox
-  var positions = this.attributes.position.array
-  var itemSize = this.attributes.position.itemSize
-  if (!positions || !itemSize || positions.length < 2) {
-    bbox.makeEmpty()
-    return
-  }
-  utils.computeBox(positions, bbox)
+  
 }


### PR DESCRIPTION
<!--
Please make sure to read the Contributing Guidelines:
https://github.com/Jam3/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the PR Title -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ * ] Other, please describe: change the code to ES6,  solve  Aframe error

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ * ] No

**Did you test your solution?**

- [ * ] I lightly tested it in one browser
- [ ] I deeply tested it in several browsers
- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)

## Problem Description

<!--- Describe the problem briefly or reference related issues -->
在Aframe框架中有一个a-text组件用到了我们的代码，但是新版的aframe有了一些ES6特性，其与我们现在代码的写法不兼容，所以做出改变

## Solution Description

<!--- Describe your changes in detail -->
将ES5的写法改为了ES6语法糖的class写法

## Side Effects, Risks, Impact

<!--- May your changes break other parts of the application? -->

- [ ] N/A

只在Aframe框架中测试通过，对其他框架的副作用，目前尚不清楚

**Aditional comments:**
