### PR TITLE
Updated TextGeometry to use ES6 class format.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,32 +1,31 @@
 var createLayout = require('layout-bmfont-text')
-var inherits = require('inherits')
 var createIndices = require('quad-indices')
 
 var vertices = require('./lib/vertices')
 var utils = require('./lib/utils')
 
-var Base = THREE.BufferGeometry
 
 module.exports = function createTextGeometry (opt) {
   return new TextGeometry(opt)
 }
 
-function TextGeometry (opt) {
-  Base.call(this)
+class TextGeometry extends THREE.BufferGeometry {
+  constructor(opt){
+    super(opt);
 
-  if (typeof opt === 'string') {
-    opt = { text: opt }
+    if (typeof opt === 'string') {
+      opt = { text: opt }
+    }
+
+    // use these as default values for any subsequent
+    // calls to update()
+    this._opt = Object.assign({}, opt)
+
+    // also do an initial setup...
+    if (opt) this.update(opt)
   }
-
-  // use these as default values for any subsequent
-  // calls to update()
-  this._opt = Object.assign({}, opt)
-
-  // also do an initial setup...
-  if (opt) this.update(opt)
 }
 
-inherits(TextGeometry, Base)
 
 TextGeometry.prototype.update = function (opt) {
   if (typeof opt === 'string') {


### PR DESCRIPTION
<!--
Please make sure to read the Contributing Guidelines:
https://github.com/Jam3/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the PR Title -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [x] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Did you test your solution?**

- [ ] I lightly tested it in one browser
- [x] I deeply tested it in several browsers
- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)

I tested all the provided samples in Edge, Chrome, and Firefox.  They all worked fine. 👍 

## Problem Description

Three-bmfont-text is incompatible with ES6 classes. 
See: https://github.com/Jam3/three-bmfont-text/issues/46

## Solution Description

```
var Base = THREE.BufferGeometry
function TextGeometry (opt) {
  Base.call(this)
...
}
inherits(TextGeometry, Base);
```

was changed to

```
class TextGeometry extends THREE.BufferGeometry {
  constructor(opt){
    super(opt);
...
  }
}
```

## Side Effects, Risks, Impact


- [x] N/A

**Aditional comments:**
